### PR TITLE
Link to official home page of CSL

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
           <div>
             Never use a reference manager again.
             Provide a DOI, ISBN, PubMed ID, URL, etc., and let Manubot generate and number citations for you.
-            Choose from <a href="https://citationstyles.org/">thousands of existing citation styles</a>.
+            Choose from <a href="https://www.zotero.org/styles">thousands</a> of existing <a title="Citation Style Language" href="https://citationstyles.org/">citation styles</a>.
             See your manuscript update right away as you make changes.
             Test and deploy automatically with <a href="https://travis-ci.org/">continuous integration</a>.
           </div>

--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
           <div>
             Never use a reference manager again.
             Provide a DOI, ISBN, PubMed ID, URL, etc., and let Manubot generate and number citations for you.
-            Choose from <a href="https://www.zotero.org/styles">thousands of existing citation styles</a>.
+            Choose from <a href="https://citationstyles.org/">thousands of existing citation styles</a>.
             See your manuscript update right away as you make changes.
             Test and deploy automatically with <a href="https://travis-ci.org/">continuous integration</a>.
           </div>


### PR DESCRIPTION
It was cool to see the PLOS paper announced at https://twitter.com/anthonygitter/status/1143540432808423426. Congrats!

It looks like Manubot uses CSL styles, so I added Manubot to our CSL home page at https://citationstyles.org/, where we maintain a list of all software products that use CSL.

Regarding this pull request, while it's fine to point users in your user documentation to the Zotero Style Repository for easy access to CSL styles (we do so ourselves at https://citationstyles.org/authors/#/finding-and-installing-styles), could you link to https://citationstyles.org/ here? It's the official home page of the CSL project, which is run independently of Zotero.