### PR TITLE
Fix catalog filter issue on load

### DIFF
--- a/catalog/index.html
+++ b/catalog/index.html
@@ -62,6 +62,7 @@ subheader: CATALOG
         new Mark(info, { accuracy: 'complementary' }).mark(searchText.trim());
       }
     }
+    window.addEventListener('load', filter);
   </script>
   <div class="row">
     <form>


### PR DESCRIPTION
Chrome (and probably other browsers) sometimes remember the state of checkboxes/textboxes/inputs when going backward then forward again in the history.

This PR adds a call to the filter on page load, in addition to whenever a checkbox is changed, so that the initial state of the checkboxes updates the entries shown in the list.